### PR TITLE
Require encryption from app to RDS

### DIFF
--- a/config/django_settings.py
+++ b/config/django_settings.py
@@ -38,6 +38,7 @@ elif os.environ['DJANGO_DB_ENV'] == "remote":
             'PASSWORD': os.environ['RDS_PASSWORD'],
             'HOST': os.environ['RDS_HOSTNAME'],
             'CONN_MAX_AGE': None,
+            'OPTIONS': {'sslmode': 'require'},
         },
     }
 else:


### PR DESCRIPTION
If I am understanding what the app is doing this is basically the only change that is a good idea to put into place. This has been tested and is working.

As things currently sat the app -> DB connection was actually encrypted by default as postgresql defaults to preferring an encrypted connection over not: https://www.postgresql.org/docs/11/libpq-ssl.html bottom of section 34.18.3. 

This change simply requires that the connection is encrypted instead of just preferring the connection to be encrypted.

I can get even fancier by verifying the SSL CA etc. however, that complexity is likely to lead towards issues in the future (the CA expires in 2020, what then?). 

It is possible to have the RDS instance require encryption using: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.create_db_parameter_group with a new parameter group created specifically for the instance. Again this probably isn't worth it with the app requiring SSL, if for no other reason than it forces a 5 minute delay when creating the parameter group before the RDS instance can be launched.

I haven't followed the entirety of your app, but it appears you are using django for the ORM and flask for the actual front end. If all DB calls are going through the django ORM, this is good enough as is. Let me know if that is not the case. 