### PR TITLE
Fix the location of the runner.sh script that batch uses to execute in the container

### DIFF
--- a/pipeline/configs/container-props.json
+++ b/pipeline/configs/container-props.json
@@ -3,6 +3,6 @@
   "memory": 2000,
   "command": [
     "/bin/bash",
-    "Pipeline/utils/runner.sh"
+    "Beiwe-Analysis/Pipeline/utils/runner.sh"
   ]
 }


### PR DESCRIPTION
Without this the pipeline simply doesn't execute at all. It fails out with the error: 
`/bin/bash: Pipeline/utils/runner.sh: No such file or directory`

This is because the Dockerfile sets the WORKDIR to /home then 'Beiwe-Analysis' is cloned into /home/.