### PR TITLE
serverless chunker

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -90,6 +90,7 @@ REDUCED_API_TIME_FORMAT = "%Y-%m-%d"
 # This value is in seconds, it sets the time period that chunked files will be sliced into.
 CHUNK_TIMESLICE_QUANTUM = 3600
 # the name of the s3 folder that contains chunked data
+RAW_DATA_FOLDER = "RAW_DATA"
 CHUNKS_FOLDER = "CHUNKED_DATA"
 PIPELINE_FOLDER = "PIPELINE_DATA"
 

--- a/database/data_access_models.py
+++ b/database/data_access_models.py
@@ -15,7 +15,7 @@ from database.study_models import Study
 from database.validators import LengthValidator
 from libs.s3 import s3_retrieve
 from libs.security import chunk_hash
-
+import codecs
 
 class FileProcessingLockedError(Exception): pass
 class UnchunkableDataTypeError(Exception): pass
@@ -89,7 +89,8 @@ class ChunkRegistry(AbstractModel):
         # easier to interpret,  make sure that there are no extraneous newline characters at the
         # end of the line. this calculation will result in the number of lines in the file being undercounted
         # by one, which will, in effect, exclude the header line from count
-        chunk_file_number_of_observations = file_contents.rstrip('\n').count('\n')
+
+        chunk_file_number_of_observations = str(codecs.decode(file_contents, "zip")).rstrip('\n').count('\n')
 
         cls.objects.create(
             is_chunkable=True,

--- a/database/data_access_models.py
+++ b/database/data_access_models.py
@@ -84,7 +84,13 @@ class ChunkRegistry(AbstractModel):
         # Django's behavior (at least on this project, but this project is set to the New York
         # timezone so it should be generalizable) is to add UTC as a timezone when storing a naive
         # datetime in the database.
-        
+       
+        # Changing file_size from size in bytes, to size in lines or number of observations, which should be 
+        # easier to interpret,  make sure that there are no extraneous newline characters at the
+        # end of the line. this calculation will result in the number of lines in the file being undercounted
+        # by one, which will, in effect, exclude the header line from count
+        chunk_file_number_of_observations = file_contents.rstrip('\n').count('\n')
+
         cls.objects.create(
             is_chunkable=True,
             chunk_path=chunk_path,
@@ -94,7 +100,7 @@ class ChunkRegistry(AbstractModel):
             study_id=study_id,
             participant_id=participant_id,
             survey_id=survey_id,
-            file_size=len(file_contents),
+            file_size=chunk_file_number_of_observations,
         )
     
     @classmethod
@@ -105,7 +111,9 @@ class ChunkRegistry(AbstractModel):
         
         if data_type in CHUNKABLE_FILES:
             raise ChunkableDataTypeError
-        
+       
+        # unchunkable data may be binary, so leave the file_size calcuation in bytes
+
         cls.objects.create(
             is_chunkable=False,
             chunk_path=chunk_path,

--- a/database/data_access_models.py
+++ b/database/data_access_models.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from django_extensions.db.fields.json import JSONField
 
 from config.constants import (CHUNK_TIMESLICE_QUANTUM, CHUNKABLE_FILES,
-    PIPELINE_FOLDER)
+    PIPELINE_FOLDER, RAW_DATA_FOLDER)
 from database.models import AbstractModel
 from database.study_models import Study
 from database.validators import LengthValidator
@@ -162,11 +162,12 @@ class FileToProcess(AbstractModel):
     def append_file_for_processing(cls, file_path, study_object_id, **kwargs):
         # Get the study's primary key
         study_pk = Study.objects.filter(object_id=study_object_id).values_list('pk', flat=True).get()
-        
-        if file_path[:24] == study_object_id:
+       
+        raw_data_study_dir = '/'.join([RAW_DATA_FOLDER, study_object_id])
+        if file_path[:len(raw_data_study_dir)] == raw_data_study_dir:
             cls.objects.create(s3_file_path=file_path, study_id=study_pk, **kwargs)
         else:
-            cls.objects.create(s3_file_path=study_object_id + '/' + file_path, study_id=study_pk, **kwargs)
+            cls.objects.create(s3_file_path=raw_data_study_dir + '/' + file_path, study_id=study_pk, **kwargs)
 
 
 class FileProcessLock(AbstractModel):

--- a/database/models.py
+++ b/database/models.py
@@ -15,7 +15,7 @@ def get_and_summarize(patient_id: str):
     print(f"Total Data Uploaded: {byte_sum/1024/1024}MB")
 
     counter = Counter(
-        path.split("/")[2] for path in
+        path.split("/")[3] for path in
         FileToProcess.objects.filter(participant=p).values_list("s3_file_path", flat=True)
     )
     return counter.most_common()

--- a/libs/file_processing_utils.py
+++ b/libs/file_processing_utils.py
@@ -161,7 +161,7 @@ def create_fake_mp4(number=10):
     participant_id = Participant.objects.get(patient_id='h6fflp')
     for x in range(number):
         with open("thing", "r") as f:
-            file_path = "55d3826297013e3a1c9b8c3e/h6fflp/voiceRecording/%s.mp4" % (1000000000 + x)
+            file_path = "RAW_DATA/55d3826297013e3a1c9b8c3e/h6fflp/voiceRecording/%s.mp4" % (1000000000 + x)
             s3_upload(file_path, f.read(), "55d3826297013e3a1c9b8c3e", raw_path=True)
             FileToProcess.append_file_for_processing(file_path, "55d3826297013e3a1c9b8c3e", participant_id=participant_id)
 

--- a/libs/graph_data.py
+++ b/libs/graph_data.py
@@ -1,5 +1,6 @@
 from flask import json
 from libs.s3 import s3_list_files, s3_retrieve
+from config.constants import RAW_DATA_FOLDER
 
 
 ################################ CSV HANDLER ###################################
@@ -34,7 +35,7 @@ def grab_file_names(study_id, survey_id, user_id, number_points):
     user_id = user_id if not isinstance(user_id, bytes) else user_id.decode()
     number_points = number_points if not isinstance(number_points, bytes) else number_points.decode()
 
-    all_files = s3_list_files("%s/%s/surveyAnswers/%s" % (str(study_id), str(user_id), str(survey_id)))
+    all_files = s3_list_files("%s/%s/%s/surveyAnswers/%s" % (RAW_DATA_FOLDER, str(study_id), str(user_id), str(survey_id)))
     return sorted(all_files[-number_points:])
 
 

--- a/libs/s3.py
+++ b/libs/s3.py
@@ -1,7 +1,7 @@
 import boto3
 import Crypto
 
-from config.constants import DEFAULT_S3_RETRIES
+from config.constants import DEFAULT_S3_RETRIES, RAW_DATA_FOLDER
 from config.settings import (BEIWE_SERVER_AWS_ACCESS_KEY_ID, BEIWE_SERVER_AWS_SECRET_ACCESS_KEY,
     S3_BUCKET, S3_REGION_NAME)
 from libs import encryption
@@ -17,7 +17,7 @@ conn = boto3.client('s3',
 
 def s3_upload(key_path: str, data_string: bytes, study_object_id: str, raw_path=False) -> None:
     if not raw_path:
-        key_path = study_object_id + "/" + key_path
+        key_path = '/'.join([RAW_DATA_FOLDER, study_object_id, key_path])
     data = encryption.encrypt_for_server(data_string, study_object_id)
     conn.put_object(Body=data, Bucket=S3_BUCKET, Key=key_path)#, ContentType='string')
 
@@ -27,7 +27,7 @@ def s3_retrieve(key_path, study_object_id, raw_path=False, number_retries=DEFAUL
     which defaults to false.  When set to false the path is prepended to place the file in the
     appropriate study_id folder. """
     if not raw_path:
-        key_path = study_object_id + "/" + key_path
+        key_path = '/'.join([RAW_DATA_FOLDER, study_object_id, key_path])
     encrypted_data = _do_retrieve(S3_BUCKET, key_path, number_retries=number_retries)['Body'].read()
     return encryption.decrypt_server(encrypted_data, study_object_id)
 

--- a/scripts/fix_ftp_raw_data_paths.py
+++ b/scripts/fix_ftp_raw_data_paths.py
@@ -1,0 +1,35 @@
+from os.path import abspath as _abspath
+from sys import path as _path
+_one_folder_up = _abspath(__file__).rsplit('/',2)[0]
+_path.insert(1, _one_folder_up)
+
+from config import load_django
+from config.constants import RAW_DATA_FOLDER
+from datetime import datetime
+
+from database.data_access_models import FileToProcess
+from libs.s3 import conn, S3_BUCKET
+from pprint import pprint
+
+print("start:", datetime.now())
+
+for ftp in FileToProcess.objects.all():
+
+    #study_pk = Study.objects.filter(object_id=study_object_id).values_list('pk', flat=True).get()
+    study_object_id = ftp.study.object_id
+    print(f'{study_object_id}: {ftp.s3_file_path}')
+
+    if ftp.s3_file_path[:len(RAW_DATA_FOLDER)] != RAW_DATA_FOLDER:
+        if ftp.s3_file_path[:len(study_object_id)] == study_object_id:
+            ftp.s3_file_path = '/'.join([RAW_DATA_FOLDER, ftp.s3_file_path])
+        else:
+            ftp.s3_file_path = '/'.join([RAW_DATA_FOLDER, study_object_id, ftp.s3_file_path])
+        ftp.save()
+
+    print(f'{study_object_id}: {ftp.s3_file_path}')
+
+    #raw_data_study_dir = '/'.join([RAW_DATA_DIR, study_object_id])
+    #if file_path[:len(raw_data_study_dir)] == raw_data_study_dir:
+        #cls.objects.create(s3_file_path=file_path, study_id=study_pk, **kwargs)
+    #else:
+        #cls.objects.create(s3_file_path=raw_data_study_dir + '/' + file_path, study_id=study_pk, **kwargs)

--- a/scripts/purge_participant_data.py
+++ b/scripts/purge_participant_data.py
@@ -18,7 +18,7 @@ _imp.load_source("__init__", _current_folder_init)
 # noinspection PyUnresolvedReferences
 from config import load_django
 from config.settings import S3_BUCKET
-from config.constants import CHUNKS_FOLDER, API_TIME_FORMAT
+from config.constants import CHUNKS_FOLDER, API_TIME_FORMAT, RAW_DATA_FOLDER
 from database.user_models import Participant
 from database.data_access_models import ChunkRegistry
 from libs.file_processing import unix_time_to_string
@@ -129,7 +129,7 @@ def assemble_deletable_files(sorted_data):
         expunge_start_date = convert_date(expunge_start_date)
         expunge_start_unix_timestamp = int((expunge_start_date - UNIX_EPOCH_START).total_seconds()) * 1000
 
-        prefix = str(participant.study.object_id) + "/" + patient_id + "/"
+        prefix = RAW_DATA_FOLDER + "/" + str(participant.study.object_id) + "/" + patient_id + "/"
         s3_files = s3_list_files(prefix, as_generator=True)
 
         chunks_prefix = CHUNKS_FOLDER + "/" + prefix

--- a/scripts/run_chunker.py
+++ b/scripts/run_chunker.py
@@ -45,8 +45,8 @@ if __name__ == "__main__":
     parser.add_argument('--run_serially', help='process the files in serial, default is to process in parallel using a threadpool',
         action='store_true', default=False)
 
-    parser.add_argument('--num_to_process', help='Only process the first N chunks, defaults to 5, set to 0 to do all',
-        type=int, default=5)
+    parser.add_argument('--num_to_process', help='Only process the first N chunks, set to 0 to do all (default)',
+        type=int, default=0)
 
     args = parser.parse_args()
 

--- a/scripts/run_chunker.py
+++ b/scripts/run_chunker.py
@@ -1,0 +1,74 @@
+from config.constants import VOICE_RECORDING
+import config.load_django
+from database.data_access_models import ChunkRegistry, FileProcessLock, FileToProcess
+
+from libs.file_processing import process_file_chunks_lambda
+import argparse
+import config.remote_db_env
+from libs.s3 import s3_retrieve
+from multiprocessing.pool import ThreadPool
+
+def check_and_update_number_of_observations(chunk):
+
+    if chunk.data_type == VOICE_RECORDING:
+        chunk.file_size = 1
+        chunk.save()
+    else:
+        file_contents = s3_retrieve(chunk.chunk_path,
+                                    study_object_id=chunk.study.object_id,
+                                    raw_path=True)
+
+        # we want to make sure that there are no extraneous newline characters at the
+        # end of the line. we want the line to end in exactly one newline character
+        file_contents = file_contents.rstrip('\n') + '\n'
+    
+        # we subtract one to exclude the header line
+        chunk.file_size = file_contents.count('\n') - 1
+        chunk.save()
+
+    print('Updated chunk {0} with {1} observations'.format(chunk, chunk.file_size))
+
+    return
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Beiwe chunker tool")
+
+    # run through all of the jobs waiting to be process and chunk them
+
+    parser.add_argument('--process_ftps', help='Chunk all of the data in the FilesToProcess table.',
+        action='store_true', default=False)
+
+    parser.add_argument('--set_num_obs', help='Set the number of observations for each chunk',
+        action='store_true', default=False)
+
+    parser.add_argument('--run_serially', help='process the files in serial, default is to process in parallel using a threadpool',
+        action='store_true', default=False)
+
+    parser.add_argument('--num_to_process', help='Only process the first N chunks, defaults to 5, set to 0 to do all',
+        type=int, default=5)
+
+    args = parser.parse_args()
+
+    if args.process_ftps:
+        process_file_chunks_lambda(args.num_to_process)
+
+    if args.set_num_obs:
+
+        pool = None
+        if not args.run_serially:
+            pool = ThreadPool(8)
+
+        if args.num_to_process > 0:
+            chunks_to_fix = ChunkRegistry.objects.filter(number_of_observations=None)[0:args.num_to_process]
+        else:
+            chunks_to_fix = list(ChunkRegistry.objects.filter(number_of_observations=None))
+
+        if args.run_serially:
+            for chunk in chunks_to_fix:
+                check_and_update_number_of_observations(chunk)
+
+        else:
+            pool.map(check_and_update_number_of_observations, chunks_to_fix)
+            pool.close()
+            pool.terminate()


### PR DESCRIPTION
A few changes to enable running the chunker as a s3-triggered lambda function. Changes include:

- storing raw data in the RAW_DATA folder of the bucket, so that the lambda function can be triggered only on raw data
- updating all relevant file parsing code, etc to accommodate the changes to raw data paths
- writing a new chunker function, that relies heavily on previous function, that can be run as a lambda
- adding scripts to test the functionality

A deploy script for deploying the lambda function is still in progress.

I additionally changed the ChunkRegistry so that file_size refers to number of lines (i.e. observations) for chunkable files, this is a bit easier to understand than bytes. Unchunkable data is still in bytes. The dashboard has not been updated to reflect this change yet.

I have tested the code changes and all appear to be working well. My guess is that this will provide a good cost reduction over the previous celery file processing cluster.

Running the file chunker as an S3-triggered lambda may make some of the open issues no longer relevant specifically: #93, #95, #97