### PR TITLE
Enables any researcher to click the link to edit_participant

### DIFF
--- a/frontend/templates/view_study.html
+++ b/frontend/templates/view_study.html
@@ -46,11 +46,7 @@
         {% for participant in participants %}
           <tr>
             <td>
-              {% if readonly %}
-                {{ participant.patient_id }}
-              {% else %}
-                <b><a href="/view_study/{{ study.id }}/edit_participant/{{ participant.id }}">{{ participant.patient_id }}</a></b>
-              {% endif %}
+              <b><a href="/view_study/{{ study.id }}/edit_participant/{{ participant.id }}">{{ participant.patient_id }}</a></b>
             </td>
             <td>
               {% if participant.device_id %}

--- a/pages/admin_pages.py
+++ b/pages/admin_pages.py
@@ -4,8 +4,7 @@ from flask import (abort, Blueprint, flash, Markup, redirect, render_template, r
 from authentication import admin_authentication
 from authentication.admin_authentication import (authenticate_researcher_login,
     authenticate_researcher_study_access, get_researcher_allowed_studies,
-    get_researcher_allowed_studies_as_query_set, get_session_researcher, researcher_is_an_admin,
-    SESSION_NAME)
+    get_researcher_allowed_studies_as_query_set, researcher_is_an_admin, SESSION_NAME)
 from config.settings import PUSH_NOTIFICATIONS_ENABLED
 from database.study_models import Study, StudyField
 from database.user_models import Participant, ParticipantFieldValue, Researcher
@@ -46,7 +45,6 @@ def choose_study():
 @authenticate_researcher_study_access
 def view_study(study_id=None):
     study = Study.objects.get(pk=study_id)
-    researcher = get_session_researcher()
     participants = study.participants.all()
 
     # creates dicts of Custom Fields and Interventions to be easily accessed in the template
@@ -66,7 +64,6 @@ def view_study(study_id=None):
         interventions=list(study.interventions.all().values_list("name", flat=True)),
         page_location='study_landing',
         study_id=study_id,
-        readonly=not researcher.check_study_admin(study_id) and not researcher.site_admin,
         push_notifications_enabled=PUSH_NOTIFICATIONS_ENABLED,
     )
 


### PR DESCRIPTION
Currently, on the View Study page, only site admins/study admins can click on a participant's ID to go to the Edit Participant page.

That's incorrect behavior; regular researchers should also be able to click on that link.  This PR fixes that and enables all users (researchers, study admins, and site admins) to click on that link.