### PR TITLE
celery control cleanup

### DIFF
--- a/api/admin_api.py
+++ b/api/admin_api.py
@@ -9,9 +9,10 @@ from config.constants import ResearcherRole
 from config.settings import DOMAIN_NAME, DOWNLOADABLE_APK_URL, IS_STAGING
 from database.study_models import Study
 from database.user_models import Researcher, StudyRelation
-from libs.push_notification_config import repopulate_all_survey_scheduled_events
+from libs.push_notification_helpers import repopulate_all_survey_scheduled_events
 from libs.security import check_password_requirements
 from libs.timezone_dropdown import ALL_TIMEZONES
+
 
 admin_api = Blueprint('admin_api', __name__)
 

--- a/api/mobile_api.py
+++ b/api/mobile_api.py
@@ -20,12 +20,12 @@ from database.profiling_models import DecryptionKeyError, UploadTracking
 from database.system_models import FileAsText
 from libs.encryption import decrypt_device_file, DecryptionKeyInvalidError, HandledError
 from libs.http_utils import determine_os_api
-from libs.push_notification_config import repopulate_all_survey_scheduled_events
+from libs.push_notification_helpers import repopulate_all_survey_scheduled_events
 from libs.s3 import get_client_public_key_string, s3_upload
 from libs.sentry import make_sentry_client, SentryTypes
 
-mobile_api = Blueprint('mobile_api', __name__)
 
+mobile_api = Blueprint('mobile_api', __name__)
 
 ################################################################################
 ################################ UPLOADS #######################################

--- a/api/participant_administration.py
+++ b/api/participant_administration.py
@@ -7,9 +7,10 @@ from authentication.admin_authentication import authenticate_researcher_study_ac
 from database.schedule_models import InterventionDate
 from database.study_models import Study
 from database.user_models import Participant, ParticipantFieldValue
-from libs.push_notification_config import repopulate_all_survey_scheduled_events
+from libs.push_notification_helpers import repopulate_all_survey_scheduled_events
 from libs.s3 import create_client_key_pair, s3_upload
 from libs.streaming_bytes_io import StreamingStringsIO
+
 
 participant_administration = Blueprint('participant_administration', __name__)
 

--- a/api/push_notifications_api.py
+++ b/api/push_notifications_api.py
@@ -9,10 +9,10 @@ from flask import Blueprint, request
 from authentication.user_authentication import authenticate_user, get_session_participant
 from config import constants
 from database.user_models import ParticipantFCMHistory
-from libs.push_notification_config import check_firebase_instance
+from libs.firebase_config import check_firebase_instance
+
 
 push_notifications_api = Blueprint('push_notifications_api', __name__)
-
 
 ################################################################################
 ########################### NOTIFICATION FUNCTIONS #############################

--- a/api/study_api.py
+++ b/api/study_api.py
@@ -7,6 +7,7 @@ from database.schedule_models import Intervention, InterventionDate
 from database.study_models import Study, StudyField
 from database.user_models import Participant, ParticipantFieldValue
 
+
 study_api = Blueprint('study_api', __name__)
 
 

--- a/api/survey_api.py
+++ b/api/survey_api.py
@@ -4,8 +4,9 @@ from authentication.admin_authentication import authenticate_researcher_study_ac
 from database.schedule_models import AbsoluteSchedule, RelativeSchedule, WeeklySchedule
 from database.survey_models import Survey
 from libs.json_logic import do_validate_survey
-from libs.push_notification_config import (repopulate_absolute_survey_schedule_events,
+from libs.push_notification_helpers import (repopulate_absolute_survey_schedule_events,
     repopulate_relative_survey_schedule_events, repopulate_weekly_survey_schedule_events)
+
 
 survey_api = Blueprint('survey_api', __name__)
 

--- a/libs/copy_study.py
+++ b/libs/copy_study.py
@@ -8,7 +8,8 @@ from database.common_models import JSONTextField
 from database.schedule_models import AbsoluteSchedule, RelativeSchedule, WeeklySchedule
 from database.study_models import Study
 from database.survey_models import Survey
-from libs.push_notification_config import repopulate_all_survey_scheduled_events
+from libs.push_notification_helpers import repopulate_all_survey_scheduled_events
+
 
 NoneType = type(None)
 
@@ -74,13 +75,13 @@ def update_device_settings(new_device_settings, study, filename):
     if request.form.get('device_settings', None) == 'true':
         # Don't copy the PK to the device settings to be updated
         purge_unnecessary_fields(new_device_settings)
-        
+
         # ah, it looks like the bug we had was that you can just send dictionary directly
         # into a textfield and it uses the __repr__ or __str__ or __unicode__ function, causing
         # weirdnesses if as_unpacked_native_python is called because json does not want to use double quotes.
         if isinstance(new_device_settings['consent_sections'], dict):
             new_device_settings['consent_sections'] = json.dumps(new_device_settings['consent_sections'])
-        
+
         study.device_settings.update(**new_device_settings)
         return f"Overwrote {study.name}'s App Settings with the values from {filename}."
     else:

--- a/libs/firebase_config.py
+++ b/libs/firebase_config.py
@@ -1,0 +1,118 @@
+import json
+from json import JSONDecodeError
+
+from firebase_admin import (delete_app as delete_firebase_instance, get_app as get_firebase_app,
+    initialize_app as initialize_firebase_app)
+from firebase_admin.credentials import Certificate as FirebaseCertificate
+
+from config.constants import (ANDROID_FIREBASE_CREDENTIALS, BACKEND_FIREBASE_CREDENTIALS,
+    FIREBASE_APP_TEST_NAME, IOS_FIREBASE_CREDENTIALS)
+from database.system_models import FileAsText
+
+
+class FirebaseMisconfigured(Exception): pass
+
+#
+# Firebase app object instantiation and credential tests
+# (This code can probably be simplified with a threading.Lock object.)
+#
+
+def safely_get_db_credential(credential_type: str) -> str or None:
+    """ just a wrapper to handle ugly code """
+    credentials = FileAsText.objects.filter(tag=credential_type).first()
+    if credentials:
+        return credentials.text
+    else:
+        return None
+
+
+def get_firebase_credential_errors(credentials: str):
+    """ Wrapper to get error strings for test_firebase_credential_errors because otherwise the
+        code is gross.  Returns None if no errors occurred. """
+    try:
+        test_firebase_credential_errors(credentials)
+        return None
+    except Exception as e:
+        return str(e)
+
+
+def test_firebase_credential_errors(credentials: str) -> None:
+    """ Tests credentials by creating a temporary otherwise unused credential. """
+    try:
+        encoded_credentials = json.loads(credentials)
+    except JSONDecodeError:
+        # need clean error message
+        raise Exception("The credentials provided are not valid JSON.")
+
+    # both of these raise ValueErrors, delete only fails if cert and app objects pass.
+    cert = FirebaseCertificate(encoded_credentials)
+    app = initialize_firebase_app(cert, name=FIREBASE_APP_TEST_NAME)
+    delete_firebase_instance(app)
+
+
+def check_firebase_instance(require_android=False, require_ios=False) -> bool:
+    """ Test the database state for the various creds. If creds are present determine whether
+    the firebase app is already instantiated, if not call update_firebase_instance. """
+
+    active_creds = list(FileAsText.objects.filter(
+        tag__in=[BACKEND_FIREBASE_CREDENTIALS, ANDROID_FIREBASE_CREDENTIALS, IOS_FIREBASE_CREDENTIALS]
+    ).values_list("tag", flat=True))
+
+    if (    # keep those parens.
+            BACKEND_FIREBASE_CREDENTIALS not in active_creds
+            or (require_android and ANDROID_FIREBASE_CREDENTIALS not in active_creds)
+            or (require_ios and IOS_FIREBASE_CREDENTIALS not in active_creds)
+    ):
+        return False
+
+    if get_firebase_credential_errors(safely_get_db_credential(BACKEND_FIREBASE_CREDENTIALS)):
+        return False
+
+    # avoid calling update so we never delete and then recreate the app (we get thrashed
+    # during push notification send from calling this, its not thread-safe), overhead is low.
+    try:
+        get_firebase_app()
+    except ValueError:
+        # we don't care about extra work inside calling update_firebase_instance, it shouldn't be
+        # hit too heavily.
+        update_firebase_instance()
+
+    return True
+
+
+def update_firebase_instance(rucur_depth=3) -> None:
+    """ Creates or destroys the firebase app, handling basic credential errors. """
+    junk_creds = False
+    encoded_credentials = None  # IDE complains
+
+    try:
+        encoded_credentials = json.loads(safely_get_db_credential(BACKEND_FIREBASE_CREDENTIALS))
+    except (JSONDecodeError, TypeError):
+        junk_creds = True
+
+    try:
+        delete_firebase_instance(get_firebase_app())
+    except ValueError:
+        # occurs when get_firebase_app() fails, delete_firebase_instance is only called if it succeeds.
+        pass
+
+    if junk_creds:
+        return
+
+    # can now ~safely initialize the firebase app, re-casting any errors for runime scenarios
+    # errors at this point should only occur if the app has somehow gotten broken credentials.
+    try:
+        cert = FirebaseCertificate(encoded_credentials)
+    except ValueError as e:
+        raise FirebaseMisconfigured(str(e))
+
+    try:
+        initialize_firebase_app(cert)
+    except ValueError as e:
+        # occasionally we do hit a race condition, handle that with 3 tries, comment in error message.
+        if rucur_depth >= 0:
+            return update_firebase_instance(rucur_depth - 1)
+        raise FirebaseMisconfigured(
+            "This error is usually caused by a race condition, please report it if this happens frequently: "
+            + str(e)
+        )

--- a/libs/push_notification_helpers.py
+++ b/libs/push_notification_helpers.py
@@ -1,128 +1,12 @@
-import json
 from datetime import datetime, timedelta
-from json import JSONDecodeError
 
-from config.constants import (ANDROID_FIREBASE_CREDENTIALS, BACKEND_FIREBASE_CREDENTIALS,
-    FIREBASE_APP_TEST_NAME, IOS_FIREBASE_CREDENTIALS)
 from database.schedule_models import ArchivedEvent, ScheduledEvent, WeeklySchedule
 from database.study_models import Study
 from database.survey_models import Survey
-from database.system_models import FileAsText
 from database.user_models import Participant
-from firebase_admin import delete_app as delete_firebase_instance
-from firebase_admin import get_app as get_firebase_app
-from firebase_admin import initialize_app as initialize_firebase_app
-from firebase_admin.credentials import Certificate as FirebaseCertificate
 
 
-class FirebaseMisconfigured(Exception): pass
 class NoSchedulesException(Exception): pass
-
-#
-# Firebase app object instantiation and credential tests
-# (This code can probably be simplified with a threading.Lock object.)
-#
-
-def safely_get_db_credential(credential_type: str) -> str or None:
-    """ just a wrapper to handle ugly code """
-    credentials = FileAsText.objects.filter(tag=credential_type).first()
-    if credentials:
-        return credentials.text
-    else:
-        return None
-
-
-def get_firebase_credential_errors(credentials: str):
-    """ Wrapper to get error strings for test_firebase_credential_errors because otherwise the
-        code is gross.  Returns None if no errors occurred. """
-    try:
-        test_firebase_credential_errors(credentials)
-        return None
-    except Exception as e:
-        return str(e)
-
-
-def test_firebase_credential_errors(credentials: str) -> None:
-    """ Tests credentials by creating a temporary otherwise unused credential. """
-    try:
-        encoded_credentials = json.loads(credentials)
-    except JSONDecodeError:
-        # need clean error message
-        raise Exception("The credentials provided are not valid JSON.")
-
-    # both of these raise ValueErrors, delete only fails if cert and app objects pass.
-    cert = FirebaseCertificate(encoded_credentials)
-    app = initialize_firebase_app(cert, name=FIREBASE_APP_TEST_NAME)
-    delete_firebase_instance(app)
-
-
-def check_firebase_instance(require_android=False, require_ios=False) -> bool:
-    """ Test the database state for the various creds. If creds are present determine whether
-    the firebase app is already instantiated, if not call update_firebase_instance. """
-
-    active_creds = list(FileAsText.objects.filter(
-        tag__in=[BACKEND_FIREBASE_CREDENTIALS, ANDROID_FIREBASE_CREDENTIALS, IOS_FIREBASE_CREDENTIALS]
-    ).values_list("tag", flat=True))
-
-    if (    # keep those parens.
-            BACKEND_FIREBASE_CREDENTIALS not in active_creds
-            or (require_android and ANDROID_FIREBASE_CREDENTIALS not in active_creds)
-            or (require_ios and IOS_FIREBASE_CREDENTIALS not in active_creds)
-    ):
-        return False
-
-    if get_firebase_credential_errors(safely_get_db_credential(BACKEND_FIREBASE_CREDENTIALS)):
-        return False
-
-    # avoid calling update so we never delete and then recreate the app (we get thrashed
-    # during push notification send from calling this, its not thread-safe), overhead is low.
-    try:
-        get_firebase_app()
-    except ValueError:
-        # we don't care about extra work inside calling update_firebase_instance, it shouldn't be
-        # hit too heavily.
-        update_firebase_instance()
-
-    return True
-
-
-def update_firebase_instance(rucur_depth=3) -> None:
-    """ Creates or destroys the firebase app, handling basic credential errors. """
-    junk_creds = False
-    encoded_credentials = None  # IDE complains
-
-    try:
-        encoded_credentials = json.loads(safely_get_db_credential(BACKEND_FIREBASE_CREDENTIALS))
-    except (JSONDecodeError, TypeError):
-        junk_creds = True
-
-    try:
-        delete_firebase_instance(get_firebase_app())
-    except ValueError:
-        # occurs when get_firebase_app() fails, delete_firebase_instance is only called if it succeeds.
-        pass
-
-    if junk_creds:
-        return
-
-    # can now ~safely initialize the firebase app, re-casting any errors for runime scenarios
-    # errors at this point should only occur if the app has somehow gotten broken credentials.
-    try:
-        cert = FirebaseCertificate(encoded_credentials)
-    except ValueError as e:
-        raise FirebaseMisconfigured(str(e))
-
-    try:
-        initialize_firebase_app(cert)
-    except ValueError as e:
-        # occasionally we do hit a race condition, handle that with 3 tries, comment in error message.
-        if rucur_depth >= 0:
-            return update_firebase_instance(rucur_depth - 1)
-        raise FirebaseMisconfigured(
-            "This error is usually caused by a race condition, please report it if this happens frequently: "
-            + str(e)
-        )
-
 
 #
 # Event scheduling

--- a/pages/admin_pages.py
+++ b/pages/admin_pages.py
@@ -1,5 +1,4 @@
-from flask import (Blueprint, flash, Markup, redirect, render_template, request, session,
-                   url_for)
+from flask import Blueprint, flash, Markup, redirect, render_template, request, session, url_for
 
 from authentication import admin_authentication
 from authentication.admin_authentication import (authenticate_researcher_login,
@@ -11,9 +10,10 @@ from constants.admin_pages import (DisableApiKeyForm, NEW_API_KEY_MESSAGE, NewAp
 from database.security_models import ApiKey
 from database.study_models import Study
 from database.user_models import Researcher
-from libs.push_notification_config import check_firebase_instance
+from libs.firebase_config import check_firebase_instance
 from libs.security import check_password_requirements
 from libs.serializers import ApiKeySerializer
+
 
 admin_pages = Blueprint('admin_pages', __name__)
 

--- a/pages/participant_pages.py
+++ b/pages/participant_pages.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+
 from django.core.paginator import EmptyPage
 from flask import abort, Blueprint, flash, redirect, render_template, request
 
@@ -9,8 +10,9 @@ from config.constants import API_DATE_FORMAT
 from database.schedule_models import ArchivedEvent
 from database.study_models import Study
 from database.user_models import Participant
-from libs.push_notification_config import (check_firebase_instance,
-    repopulate_all_survey_scheduled_events)
+from libs.firebase_config import check_firebase_instance
+from libs.push_notification_helpers import repopulate_all_survey_scheduled_events
+
 
 participant_pages = Blueprint('participant_pages', __name__)
 

--- a/pages/survey_designer.py
+++ b/pages/survey_designer.py
@@ -6,7 +6,8 @@ from authentication.admin_authentication import (authenticate_researcher_study_a
     get_researcher_allowed_studies, researcher_is_an_admin)
 from config.settings import DOMAIN_NAME
 from database.survey_models import Survey
-from libs.push_notification_config import check_firebase_instance
+from libs.firebase_config import check_firebase_instance
+
 
 survey_designer = Blueprint('survey_designer', __name__)
 

--- a/pages/system_admin_pages.py
+++ b/pages/system_admin_pages.py
@@ -3,7 +3,7 @@ import plistlib
 from collections import defaultdict
 
 from django.core.exceptions import ValidationError
-from flask import (abort, Blueprint, escape, flash, Markup, redirect, render_template, request)
+from flask import abort, Blueprint, escape, flash, Markup, redirect, render_template, request
 
 from authentication.admin_authentication import (assert_admin, assert_researcher_under_admin,
     authenticate_admin, authenticate_researcher_study_access, get_researcher_allowed_studies,
@@ -14,9 +14,8 @@ from database.study_models import Study
 from database.system_models import FileAsText
 from database.user_models import Researcher, StudyRelation
 from libs.copy_study import copy_existing_study
+from libs.firebase_config import get_firebase_credential_errors, update_firebase_instance
 from libs.http_utils import checkbox_to_boolean, string_to_int
-from libs.push_notification_config import (get_firebase_credential_errors,
-    update_firebase_instance)
 from libs.sentry import make_error_sentry, SentryTypes
 from libs.timezone_dropdown import ALL_TIMEZONES_DROPDOWN
 from pages.message_strings import (ALERT_ANDROID_DELETED_TEXT, ALERT_ANDROID_SUCCESS_TEXT,
@@ -24,6 +23,7 @@ from pages.message_strings import (ALERT_ANDROID_DELETED_TEXT, ALERT_ANDROID_SUC
     ALERT_FIREBASE_DELETED_TEXT, ALERT_IOS_DELETED_TEXT, ALERT_IOS_SUCCESS_TEXT,
     ALERT_IOS_VALIDATION_FAILED_TEXT, ALERT_MISC_ERROR_TEXT, ALERT_SPECIFIC_ERROR_TEXT,
     ALERT_SUCCESS_TEXT)
+
 
 system_admin_pages = Blueprint('system_admin_pages', __name__)
 SITE_ADMIN = "Site Admin"

--- a/services/celery_push_notifications.py
+++ b/services/celery_push_notifications.py
@@ -14,7 +14,8 @@ from config.study_constants import OBJECT_ID_ALLOWED_CHARS
 from database.schedule_models import ArchivedEvent, ScheduledEvent
 from database.user_models import Participant, ParticipantFCMHistory, PushNotificationDisabledEvent
 from libs.celery_control import push_send_celery_app, safe_apply_async
-from libs.push_notification_config import check_firebase_instance, set_next_weekly
+from libs.firebase_config import check_firebase_instance
+from libs.push_notification_helpers import set_next_weekly
 from libs.sentry import make_error_sentry, SentryTypes
 
 


### PR DESCRIPTION
(This is the second in a sequence of pull requests containing several bugfixes and rebases)

This is a refactoring and separation of different components of celery, firebase, and push notification code.

Rebase pull request of the first pull request:
https://github.com/onnela-lab/beiwe-backend/pull/231

original session timestamp bugfix pull request:
https://github.com/onnela-lab/beiwe-backend/pull/221

There have been some posted errors similar to this, Alvin posted a fix that hit most cases at some point in the past month, but I just spun up a local server from scratch and immediately hit this bug after logging in as the default admin.

Fix is to test the correct date-time object in the ~authentication decorator.

