### PR TITLE
[fix-deployment-for-password-protected-ssh-keys] 

### DIFF
--- a/cluster_management/launch_script.py
+++ b/cluster_management/launch_script.py
@@ -55,7 +55,7 @@ from deployment_helpers.general_utils import current_time_string, do_zip_reducti
 # Fabric configuration
 class FabricExecutionError(Exception): pass
 fabric_env.abort_exception = FabricExecutionError
-fabric_env.abort_on_prompts = True
+fabric_env.abort_on_prompts = False
 
 parser = argparse.ArgumentParser(description="interactive set of commands for deploying a Beiwe Cluster")
 
@@ -110,8 +110,8 @@ def push_manager_private_ip_and_password(eb_environment_name):
     # echo puts a new line at the end of the output
     run(f"echo {ip} > {REMOTE_RABBIT_MQ_PASSWORD_FILE_PATH}")
     run(f"printf {password} >> {REMOTE_RABBIT_MQ_PASSWORD_FILE_PATH}")
-    
-    
+
+
 def push_home_directory_files():
     for local_relative_file, remote_relative_file in FILES_TO_PUSH:
         local_file_path = path_join(PUSHED_FILES_FOLDER, local_relative_file)
@@ -192,7 +192,7 @@ def setup_rabbitmq(eb_environment_name):
     # push the configuration file so that it listens on the configured port
     put(LOCAL_RABBIT_MQ_CONFIG_FILE_PATH, REMOTE_RABBIT_MQ_CONFIG_FILE_PATH)
     sudo(f"cp {REMOTE_RABBIT_MQ_CONFIG_FILE_PATH} {REMOTE_RABBIT_MQ_FINAL_CONFIG_FILE_PATH}")
-    
+
     # setup a new password
     sudo(f"rabbitmqctl add_user beiwe {get_rabbit_mq_password(eb_environment_name)}")
     sudo('rabbitmqctl set_permissions -p / beiwe ".*" ".*" ".*"')
@@ -295,7 +295,7 @@ def do_fail_if_bad_environment_name(name):
     if not (4 <= len(name) < 40):
         log.error("That name is either too long or too short.")
         EXIT(1)
-    
+
     if not re.match("^[a-zA-Z0-9-]+$", name) or name.endswith("-"):
         log.error("that is not a valid Elastic Beanstalk environment name.")
         EXIT(1)
@@ -326,13 +326,13 @@ def prompt_for_extant_eb_environment_name():
 
 def do_setup_eb_update():
     print("\n", DO_SETUP_EB_UPDATE_OPEN)
-    
+
     files = sorted([f for f in os.listdir(STAGED_FILES) if f.lower().endswith(".zip")])
-    
+
     if not files:
         print("Could not find any zip files in " + STAGED_FILES)
         EXIT(1)
-    
+
     print("Enter the version of the codebase do you want to use:")
     for i, file_name in enumerate(files):
         print("[%s]: %s" % (i + 1, file_name))
@@ -343,11 +343,11 @@ def do_setup_eb_update():
         log.error("Could not parse input.")
         index = None  # ide warnings
         EXIT(1)
-    
+
     if index < 1 or index > len(files):
         log.error("%s was not a valid option." % index)
         EXIT(1)
-    
+
     # handle 1-indexing
     file_name = files[index - 1]
     # log.info("Processing %s..." % file_name)
@@ -381,34 +381,34 @@ def do_help_setup_new_environment():
     beiwe_environment_fp = get_beiwe_python_environment_variables_file_path(name)
     processing_server_settings_fp = get_server_configuration_file_path(name)
     extant_files = os.listdir(DEPLOYMENT_SPECIFIC_CONFIG_FOLDER)
-    
+
     for fp in (beiwe_environment_fp, processing_server_settings_fp):
         if os.path.basename(fp) in extant_files:
             log.error("is already a file at %s" % relpath(beiwe_environment_fp))
             EXIT(1)
-    
+
     with open(beiwe_environment_fp, 'w') as f:
         json.dump(reference_environment_configuration_file(), f, indent=1)
     with open(processing_server_settings_fp, 'w') as f:
         json.dump(reference_data_processing_server_configuration(), f, indent=1)
-    
+
     print("Environment specific files have been created at %s and %s." % (
         relpath(beiwe_environment_fp),
         relpath(processing_server_settings_fp),
     ))
-    
+
     # Note: we actually cannot generate RDS credentials until we have a server, this is because
     # the hostname cannot exist until the server exists.
     print("""After filling in the required contents of these newly created files you will be able
     to run the -create-environment command.  Note that several more credentials files will be
     generated as part of that process. """)
-    
+
 
 def do_create_manager():
     name = prompt_for_extant_eb_environment_name()
     do_fail_if_environment_does_not_exist(name)
     create_processing_server_configuration_file(name)
-    
+
     try:
         settings = get_server_configuration_file(name)
     except Exception as e:
@@ -416,7 +416,7 @@ def do_create_manager():
         log.error(e)
         settings = None  # ide warnings...
         EXIT(1)
-        
+
     log.info("creating manager server for %s..." % name)
     try:
         instance = create_processing_control_server(name, settings[MANAGER_SERVER_INSTANCE_TYPE])
@@ -425,7 +425,7 @@ def do_create_manager():
         instance = None  # ide warnings...
         EXIT(1)
     public_ip = instance['NetworkInterfaces'][0]['PrivateIpAddresses'][0]['Association']['PublicIp']
-    
+
     configure_fabric(name, public_ip)
     create_swap()
     push_home_directory_files()
@@ -449,7 +449,7 @@ def do_create_worker():
         log.error(
             "There is no manager server for the %s cluster, cannot deploy a worker until there is." % name)
         EXIT(1)
-    
+
     try:
         settings = get_server_configuration_file(name)
     except Exception as e:
@@ -457,7 +457,7 @@ def do_create_worker():
         log.error(e)
         settings = None  # ide warnings...
         EXIT(1)
-    
+
     log.info("creating worker server for %s..." % name)
     try:
         instance = create_processing_server(name, settings[WORKER_SERVER_INSTANCE_TYPE])
@@ -466,7 +466,7 @@ def do_create_worker():
         instance = None  # ide warnings...
         EXIT(1)
     instance_ip = instance['NetworkInterfaces'][0]['PrivateIpAddresses'][0]['Association']['PublicIp']
-    
+
     configure_fabric(name, instance_ip)
     create_swap()
     push_home_directory_files()
@@ -500,8 +500,8 @@ def do_create_single_server_ami(ip_address, key_filename):
     setup_single_server_ami_cron()
     configure_apache()
     remove_unneeded_ssh_keys()
-    
-    
+
+
 def do_fix_health_checks():
     name = prompt_for_extant_eb_environment_name()
     do_fail_if_environment_does_not_exist(name)
@@ -512,7 +512,7 @@ def do_fix_health_checks():
         log.error("unable to run command due to the following error:\n %s" % e)
         raise
     print("Success.")
-    
+
 
 def do_terminate_all_processing_servers():
     name = prompt_for_extant_eb_environment_name()
@@ -595,11 +595,11 @@ if __name__ == "__main__":
     if arguments.create_environment:
         do_create_environment()
         EXIT(0)
-        
+
     if arguments.create_manager:
         do_create_manager()
         EXIT(0)
-    
+
     if arguments.create_worker:
         do_create_worker()
         EXIT(0)
@@ -607,7 +607,7 @@ if __name__ == "__main__":
     if arguments.fix_health_checks_blocking_deployment:
         do_fix_health_checks()
         EXIT(0)
-    
+
     if arguments.purge_instance_profiles:
         print(PURGE_COMMAND_BLURB, "\n\n\n")
         iam_purge_instance_profiles()


### PR DESCRIPTION
Sets fabric to not explode on prompts.

While blocking prompts entirely is useful during development, AWS can now provide keys with passwords - I seem to recall this was not a thing when originally developed - and we have had some issues posted where this was the culprit.

