### PR TITLE
In GitHub Actions: catch `git pull` failure on worker server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,4 +78,14 @@ jobs:
           mkdir -p ~/.ssh/
           echo "$SSH_KEY" > ~/.ssh/staging.key
           chmod 600 ~/.ssh/staging.key
-          ssh -i ~/.ssh/staging.key -o StrictHostKeyChecking=no ubuntu@"$WORKER_HOSTNAME" 'cd beiwe-backend;git pull;pkill -HUP supervisord'
+          # SSH into the remote server, cd into beiwe-backend, run git pull, then restart supervisord.
+          # If `git pull` fails, exit the SSH session, and percolate that up into killing this script.
+          if ! ssh -i ~/.ssh/staging.key -o StrictHostKeyChecking=no ubuntu@"$WORKER_HOSTNAME" \
+            'cd beiwe-backend; \
+            if ! git pull; \
+              then exit 1; \
+            fi; \
+            pkill -HUP supervisord;'; \
+          then \
+            exit 1; \
+          fi


### PR DESCRIPTION
Inside GitHub Actions CI/CD, if `git pull` errors/fails, cause the whole GitHub Action to fail.

This is needed because we had a situation on one of the worker servers where the beiwe-backend repo had uncommitted changes in it, and that made `git pull` not do anything. so the code on the worker server didn't actually get updated, even though the GitHub Action indicated that it completed successfully.  Now, if that happens (or if GitHub Actions fails to SSH into the worker server), the Action should fail.