### PR TITLE
GitHub Actions: add sudo to data processing restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
             if ! git pull; \
               then exit 1; \
             fi; \
-            pkill -HUP supervisord;'; \
+            sudo pkill -HUP supervisord;'; \
           then \
             exit 1; \
           fi


### PR DESCRIPTION
When GitHub Actions restarts data processing on a worker server, it needs to use `sudo`.  This is a very small change; I tested it on one production deployment and I'm going to merge it without review.