### PR TITLE
Replace pycrypto with pycryptodome in its last two occurrences

### DIFF
--- a/libs/rsa.py
+++ b/libs/rsa.py
@@ -37,7 +37,7 @@ def prepare_X509_key_for_java(exported_key) -> bytes:
     return b"".join(exported_key.split(b'\n')[1:-1])
 
 
-def get_RSA_cipher(key: bytes) -> old_RSA._RSAobj:
+def get_RSA_cipher(key: bytes) -> old_RSA.RsaKey:
     return old_RSA.importKey(key)
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ python-dateutil==2.8.2
 # We used to use pycrypto, now we use pycryptodome, but we can't get pycryptodome to decrypt RSA
 # stuff backwards-compatibly.  Pycrypto RSA decryption is not compatible with Python versions
 # greater than 3.7 without a patch to the time library.  There are Fixmes for expunging it elsewhere.
-pycrypto==2.6.1
+pycryptodome==3.11.0
 pycryptodomex==3.11.0  # locked version
 
 # error reporting

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pycrypto==2.6.1
+pycryptodome==3.11.0
     # via -r requirements.in
 pycryptodomex==3.11.0
     # via -r requirements.in


### PR DESCRIPTION
@biblicabeebli you've already done the yeoman's work of replacing pycrypto with pycryptodome in almost all places.  But on the `main` branch, the no-longer-supported pycrypto library is still used in two remaining places.  The main one is getting RSA keys in `libs/rsa.py`; the other is for randomness generation in `tests`.

I ran into error #280 when running locally (Ubuntu 18.04, Python 3.8.12):
```
  File ".../beiwe-backend/libs/rsa.py", line 4, in <module>
    from Crypto.PublicKey import RSA as old_RSA
  File ".../.virtualenvs/beiwe-backend/lib/python3.8/site-packages/Crypto/PublicKey/RSA.py", line 585
    except ValueError, IndexError:
                     ^
SyntaxError: invalid syntax
```
This looks to me like this error is because PyCrypto is still using Python 2 syntax for the `except` clause, which is invalid in Python 3.  PyCrypto keeps causing problems like this, so I'm wondering if there's a way to finally get rid of it completely.

I know you've built some ingenious workarounds for keeping PyCrypto working.  But I just tried out swapping PyCrypto for PyCryptodome in this PR, and I'm getting the same RSA keys returned, so I think it should work!  And if it does, this would let us fully remove PyCrypto and the workarounds in `launch_script.py`.

This is the testing I did in a Python shell:
```python
participant = Participant.objects.get(patient_id='...')
participant.get_private_key().exportKey()
get_client_public_key(participant.patient_id, participant.study.object_id).exportKey()
```
I ran this on the current `main` branch (on the staging EB environment), and I ran it on this PR (locally), using the same public-private key pair, and I got the same return values.

What do you think?  Are there any problems with this PR that I'm missing?