### PR TITLE
Add CI workflow for running tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+relative_files = true
 source =
     authentication
     config

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,32 @@
+[run]
+source =
+    authentication
+    config
+    constants
+    database
+    endpoints
+    libs
+    middleware
+    services
+omit =
+    */migrations/*
+    */__pycache__/*
+    */tests/*
+branch = true
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if TYPE_CHECKING:
+    if __name__ == .__main__.:
+show_missing = true
+skip_covered = false
+fail_under = 0
+
+[html]
+directory = htmlcov
+
+[xml]
+output = coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+# CI workflow for running tests
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: beiwe
+          POSTGRES_PASSWORD: beiwe_test_password
+          POSTGRES_DB: beiwe_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Django/Beiwe settings
+      DOMAIN_NAME: localhost
+      FLASK_SECRET_KEY: test_secret_key_for_ci_only
+      S3_BUCKET: test-bucket
+      BEIWE_SERVER_AWS_ACCESS_KEY_ID: test_access_key
+      BEIWE_SERVER_AWS_SECRET_ACCESS_KEY: test_secret_key
+      # Database settings
+      RDS_DB_NAME: beiwe_test
+      RDS_USERNAME: beiwe
+      RDS_PASSWORD: beiwe_test_password
+      RDS_HOSTNAME: localhost
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+          pip install -r requirements_testing.txt
+
+      - name: Run database migrations
+        run: python manage.py migrate
+
+      - name: Run tests
+        run: python manage.py test --verbosity=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       RDS_USERNAME: beiwe
       RDS_PASSWORD: beiwe_test_password
       RDS_HOSTNAME: localhost
+      # Disable SSL for PostgreSQL (CI container doesn't support SSL)
+      RUNNING_IN_DOCKER: "true"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,23 @@ jobs:
       - name: Run database migrations
         run: python manage.py migrate
 
-      - name: Run tests
-        run: python manage.py test --verbosity=2
+      - name: Run tests with coverage
+        run: |
+          coverage run manage.py test --verbosity=2
+          coverage report
+          coverage xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            htmlcov/
+          retention-days: 30
+
+      - name: Coverage comment on PR
+        uses: py-cov-action/python-coverage-comment-action@v3
+        if: github.event_name == 'pull_request'
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       DOMAIN_NAME: localhost
       FLASK_SECRET_KEY: test_secret_key_for_ci_only
       S3_BUCKET: test-bucket
+      SYSADMIN_EMAILS: test@test.com
       BEIWE_SERVER_AWS_ACCESS_KEY_ID: test_access_key
       BEIWE_SERVER_AWS_SECRET_ACCESS_KEY: test_secret_key
       # Database settings

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .idea/
 .python-version
 .coverage
+coverage.xml
 .vscode
 htmlcov/
 .ropeproject


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that runs the Django test suite
- Triggers on pushes to `main` and pull requests targeting `main`
- Sets up PostgreSQL 16 service container for the test database
- Configures required environment variables with test values

## Test plan
- [ ] Verify the CI workflow runs successfully on this PR
- [ ] Confirm all tests pass in the GitHub Actions environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)