### PR TITLE
Add automatic Enrollment Date intervention for new studies

### DIFF
--- a/endpoints/mobile_endpoints.py
+++ b/endpoints/mobile_endpoints.py
@@ -28,6 +28,7 @@ from database.user_models_participant import AppHeartbeats, Participant, Partici
 from libs.encryption import (DecryptionKeyInvalidError, DeviceDataDecryptor,
     IosDecryptionKeyDuplicateError, IosDecryptionKeyNotFoundError, RemoteDeleteFileScenario)
 from libs.endpoint_helpers.graph_data_helpers import get_survey_results
+from libs.intervention_utils import set_enrollment_date
 from libs.endpoint_helpers.participant_file_upload_helpers import (
     upload_and_create_file_to_process_and_log, upload_problem_file)
 from libs.firebase_config import check_firebase_instance
@@ -196,6 +197,8 @@ def register_user(request: ParticipantRequest, OS_API=""):
         request.session_participant.update_only(last_register_user=now)
     else:
         request.session_participant.update_only(last_register_user=now, first_register_user=now)
+        # Automatically set the Enrollment Date intervention date on first registration
+        set_enrollment_date(request.session_participant)
     if (
         'patient_id' not in request.POST or 'device_id' not in request.POST
         or 'phone_number' not in request.POST or 'new_password' not in request.POST

--- a/endpoints/study_endpoints.py
+++ b/endpoints/study_endpoints.py
@@ -26,6 +26,7 @@ from database.user_models_researcher import Researcher, StudyRelation
 from libs.django_forms.forms import StudyEndDateForm, StudySecuritySettingsForm
 from libs.endpoint_helpers.copy_study_helpers import (allowed_file_extension, copy_study_from_json,
     do_duplicate_step, study_settings_fileresponse, unpack_json_study)
+from libs.intervention_utils import create_enrollment_date_intervention_for_study
 from libs.endpoint_helpers.password_validation_helpers import get_min_password_requirement
 from libs.endpoint_helpers.researcher_helpers import get_administerable_researchers
 from libs.endpoint_helpers.study_helpers import (conditionally_display_study_status_warnings,
@@ -254,6 +255,8 @@ def create_study(request: ResearcherRequest):
         new_study = Study.create_with_object_id(
             name=name, encryption_key=encryption_key, forest_enabled=forest_enabled
         )
+        # Create the automatic "Enrollment Date" intervention for the new study
+        create_enrollment_date_intervention_for_study(new_study)
         if duplicate_existing_study:
             do_duplicate_step(request, new_study)
         messages.success(request, f"Successfully created study `{name}`.  Review your study's device settings below.")

--- a/tests/test_mobile_endpoints.py
+++ b/tests/test_mobile_endpoints.py
@@ -16,9 +16,10 @@ from constants.study_constants import (ABOUT_PAGE_TEXT, CONSENT_FORM_TEXT, DEFAU
     SURVEY_SUBMIT_SUCCESS_TOAST_TEXT)
 from constants.testing_constants import MIDNIGHT_EVERY_DAY_OF_WEEK, THURS_OCT_6_NOON_2022_NY
 from database.models import (AbsoluteSchedule, AppHeartbeats, AppVersionHistory, FileToProcess,
-    GenericEvent, Participant, ParticipantFCMHistory, ScheduledEvent, WeeklySchedule)
+    GenericEvent, Intervention, InterventionDate, Participant, ParticipantFCMHistory, ScheduledEvent, WeeklySchedule)
 from libs.endpoint_helpers.participant_file_upload_helpers import (
     upload_and_create_file_to_process_and_log)
+from libs.intervention_utils import ENROLLMENT_DATE_INTERVENTION_NAME
 from libs.rsa import get_RSA_cipher
 from libs.schedules import (get_start_and_end_of_java_timings_week,
     repopulate_absolute_survey_schedule_events, repopulate_relative_survey_schedule_events)
@@ -708,6 +709,71 @@ class TestRegisterParticipant(ParticipantSessionTest):
         self.assertEqual(response.content, b"")
         self.assertIsNone(self.default_participant.last_register_user)
         self.assertIsNone(self.default_participant.first_register_user)
+
+    @patch("endpoints.mobile_endpoints.get_participant_public_key_string")
+    def test_first_registration_sets_enrollment_date(self, get_participant_public_key_string: MagicMock):
+        """Test that first registration sets the enrollment date intervention in study timezone."""
+        get_participant_public_key_string.return_value = "a_private_key"
+        # Create the Enrollment Date intervention for this study (simulating a new study)
+        enrollment_intervention = Intervention.objects.create(
+            study=self.session_study,
+            name=ENROLLMENT_DATE_INTERVENTION_NAME
+        )
+        # Create blank InterventionDate for the participant (simulating add_fields_and_interventions)
+        InterventionDate.objects.create(
+            participant=self.session_participant,
+            intervention=enrollment_intervention,
+            date=None
+        )
+        # Register the participant
+        self.smart_post_status_code(200, **self.BASIC_PARAMS)
+        # Verify the enrollment date was set to today in the study's timezone
+        intervention_date = InterventionDate.objects.get(
+            participant=self.session_participant,
+            intervention=enrollment_intervention
+        )
+        expected_date = timezone.now().astimezone(self.session_study.timezone).date()
+        self.assertEqual(intervention_date.date, expected_date)
+
+    @patch("endpoints.mobile_endpoints.get_participant_public_key_string")
+    def test_subsequent_registration_does_not_change_enrollment_date(self, get_participant_public_key_string: MagicMock):
+        """Test that subsequent registrations don't change the enrollment date."""
+        get_participant_public_key_string.return_value = "a_private_key"
+        # Create the Enrollment Date intervention
+        enrollment_intervention = Intervention.objects.create(
+            study=self.session_study,
+            name=ENROLLMENT_DATE_INTERVENTION_NAME
+        )
+        # Create InterventionDate with a specific date (simulating previous registration)
+        original_date = date(2024, 1, 15)
+        InterventionDate.objects.create(
+            participant=self.session_participant,
+            intervention=enrollment_intervention,
+            date=original_date
+        )
+        # Set last_register_user to simulate already registered (code checks last_register_user)
+        self.session_participant.update(last_register_user=timezone.now(), first_register_user=timezone.now())
+        # Register again
+        self.smart_post_status_code(200, **self.BASIC_PARAMS)
+        # Verify the enrollment date was NOT changed
+        intervention_date = InterventionDate.objects.get(
+            participant=self.session_participant,
+            intervention=enrollment_intervention
+        )
+        self.assertEqual(intervention_date.date, original_date)
+
+    @patch("endpoints.mobile_endpoints.get_participant_public_key_string")
+    def test_registration_without_intervention_does_nothing(self, get_participant_public_key_string: MagicMock):
+        """Test that registration without Enrollment Date intervention doesn't create one."""
+        get_participant_public_key_string.return_value = "a_private_key"
+        # Don't create the Enrollment Date intervention (simulating existing study before feature)
+        # Verify no interventions exist
+        self.assertEqual(Intervention.objects.filter(study=self.session_study).count(), 0)
+        # Register the participant
+        self.smart_post_status_code(200, **self.BASIC_PARAMS)
+        # Verify no intervention was created
+        self.assertEqual(Intervention.objects.filter(study=self.session_study).count(), 0)
+        self.assertEqual(InterventionDate.objects.filter(participant=self.session_participant).count(), 0)
 
 
 class TestGetLatestDeviceSettings(ParticipantSessionTest):


### PR DESCRIPTION
## Summary

- Automatically creates an "Enrollment Date" intervention when a new study is created
- Sets the enrollment date when a participant first registers via the mobile app (using the study's timezone)
- Existing studies are unaffected - no intervention is created on-the-fly

## Changes

| File | Changes |
|------|---------|
| `libs/intervention_utils.py` | Add `ENROLLMENT_DATE_INTERVENTION_NAME` constant, `create_enrollment_date_intervention_for_study()`, and `set_enrollment_date()` functions |
| `endpoints/study_endpoints.py` | Create intervention on study creation |
| `endpoints/mobile_endpoints.py` | Set enrollment date on first registration |
| `tests/test_study_endpoints.py` | Add test for intervention creation |
| `tests/test_mobile_endpoints.py` | Add 3 tests for enrollment date behavior |

## Behavior

- **New studies**: Automatically get an "Enrollment Date" intervention
- **First registration**: Participant's enrollment date is set to today (in study timezone)
- **Re-registration**: No change to enrollment date
- **Existing studies**: Unaffected (no intervention created retroactively)

## Test plan

- [x] `test_create_study_creates_enrollment_date_intervention` - Verify intervention created on study creation
- [x] `test_first_registration_sets_enrollment_date` - Verify date set on first registration
- [x] `test_subsequent_registration_does_not_change_enrollment_date` - Verify re-registration doesn't change date
- [x] `test_registration_without_intervention_does_nothing` - Verify existing studies unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)